### PR TITLE
Fix color mode sync bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1142,11 +1142,15 @@
                     ...node,
                     color: getNodeColor(node)
                 }));
-                
+
                 if (nodes) {
                     nodes.update(updatedNodes);
                 }
-                
+
+                // Keep originalData in sync so other interactions use the
+                // correct colors after switching modes
+                originalData.nodes = updatedNodes;
+
                 if (mode === 'community') {
                     createCommunityLegend();
                 }


### PR DESCRIPTION
## Summary
- maintain original node colors when switching between risk and community modes

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_687bfbe289548323a1149eba6b229079